### PR TITLE
Added the movie id & 'seen'/'want' buttons to the bottom of each movie card pop-up

### DIFF
--- a/src/MovieTheater/Controllers/APIController.cs
+++ b/src/MovieTheater/Controllers/APIController.cs
@@ -74,6 +74,20 @@ namespace MovieTheater.Controllers
             return BadRequest(new { Success = false, Message = "Movie ID not found" });
         }
 
+        [HttpGet("/API/GetTotalMovieCount")]
+        public async Task<IActionResult> GetTotalMovieCount()
+        {
+            try
+            {
+                var count = await movieDb.Movies.CountAsync();
+                return Ok(new { totalCount = count, success = true });
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(new { totalCount = 0, success = false, error = ex.Message });
+            }
+        }
+
         [HttpPost("/API/InsertMovie")]
         public async Task<IActionResult> InsertMovie([FromBody] Movie movie)
         {

--- a/src/ui/src/MovieAPI.js
+++ b/src/ui/src/MovieAPI.js
@@ -176,6 +176,14 @@ function imdbApiLookupName(name) {
   });
 }
 
+function getTotalMovieCount() {
+  const url = "/API/GetTotalMovieCount";
+
+  return fetch(url, {
+    method: "get",
+  });
+}
+
 const MovieAPI = {
   getMoviePoster,
   getPosterThumbnail,
@@ -183,6 +191,7 @@ const MovieAPI = {
   getMovie,
   getUsers,
   insertMovie,
+  getTotalMovieCount,
   tmdbLookupImdbID,
   tmdbLookupName,
   omdbLookupImdbID,

--- a/src/ui/src/Pages/Browse/Browse.js
+++ b/src/ui/src/Pages/Browse/Browse.js
@@ -35,7 +35,13 @@ function Browse({ search, userData, setUserData, actorSearch }) {
           actorSearch={actorSearch}
           onMovieClick={handleOpenMovie}
         />
-        <MovieModal movieId={selectedMovieId} visible={isModalVisible} onClose={handleCloseModal} actorSearch={actorSearch} />
+        <MovieModal
+          movieId={selectedMovieId}
+          visible={isModalVisible}
+          onClose={handleCloseModal}
+          actorSearch={actorSearch}
+          movieDataArray={movieDataArray}
+        />
       </>
     );
   } else {

--- a/src/ui/src/Pages/Browse/Browse.js
+++ b/src/ui/src/Pages/Browse/Browse.js
@@ -41,6 +41,8 @@ function Browse({ search, userData, setUserData, actorSearch }) {
           onClose={handleCloseModal}
           actorSearch={actorSearch}
           movieDataArray={movieDataArray}
+          userData={userData}
+          setUserData={setUserData}
         />
       </>
     );

--- a/src/ui/src/Pages/Browse/CardList.js
+++ b/src/ui/src/Pages/Browse/CardList.js
@@ -83,17 +83,21 @@ const cardRightColumStyle = {
 };
 
 const filmIcon = {
-  fontSize: "30px",
-  width: "35px",
-  verticalAlign: "middle",
-  paddingRight: "30px",
+  fontSize: "24px",
+  width: "24px",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  marginRight: "8px",
 };
 
 const heartIcon = {
-  fontSize: "25px",
-  width: "30px",
-  verticalAlign: "middle",
-  paddingRight: "5px",
+  fontSize: "24px",
+  width: "24px",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  marginRight: "8px",
 };
 
 const buttonLabelStyle = {
@@ -103,22 +107,28 @@ const buttonLabelStyle = {
 
 const hasWatchedDataContainer = {
   width: "100px",
+  height: "44px",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
   margin: "auto",
   marginLeft: "-20px",
   float: "left",
   color: "#a9a9a9",
 };
-//when watched: #4169e3
 
 const toWatchDataContainer = {
   width: "100px",
+  height: "44px",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
   margin: "auto",
   marginLeft: "10px",
   paddingRight: "20px",
   float: "left",
   color: "#a9a9a9",
 };
-//when wanted: #dc143c
 
 function UserMovieOptions({ userData, id, setUserData }) {
   const [hoveredSeenButton, setHoveredSeenButton] = useState(false);

--- a/src/ui/src/Pages/Browse/MovieModal.js
+++ b/src/ui/src/Pages/Browse/MovieModal.js
@@ -3,7 +3,174 @@ import { useState, useEffect } from "react";
 import { Modal, Spin } from "antd";
 import { Link } from "react-router-dom";
 
-function MovieModal({ movieId, visible, onClose, actorSearch, movieDataArray }) {
+const filmIcon = {
+  fontSize: "30px",
+  width: "35px",
+  verticalAlign: "middle",
+  paddingRight: "30px",
+};
+
+const heartIcon = {
+  fontSize: "25px",
+  width: "30px",
+  verticalAlign: "middle",
+  paddingRight: "5px",
+};
+
+const buttonLabelStyle = {
+  fontWeight: "bold",
+  verticalAlign: "middle",
+};
+
+const hasWatchedDataContainer = {
+  width: "100px",
+  margin: "auto",
+  marginLeft: "-20px",
+  float: "left",
+  color: "#a9a9a9",
+};
+
+const toWatchDataContainer = {
+  width: "100px",
+  margin: "auto",
+  marginLeft: "10px",
+  paddingRight: "20px",
+  float: "left",
+  color: "#a9a9a9",
+};
+
+function UserMovieOptions({ userData, id, setUserData, inline = false }) {
+  const [hoveredSeenButton, setHoveredSeenButton] = useState(false);
+  const [hoveredWantButton, setHoveredWantButton] = useState(false);
+
+  if (userData) {
+    const isWatched = userData.moviesSeen.includes(id);
+    let watchedDataContainer;
+
+    if (isWatched) {
+      watchedDataContainer = {
+        ...hasWatchedDataContainer,
+        color: "#4169e3",
+      };
+    } else {
+      watchedDataContainer = {
+        ...hasWatchedDataContainer,
+        color: hoveredSeenButton ? "#52c41a" : "#a9a9a9",
+      };
+    }
+
+    const isWanted = userData.moviesToWatch.includes(id);
+    let wantedDataContainer;
+    if (isWanted) {
+      wantedDataContainer = {
+        ...toWatchDataContainer,
+        color: "#dc143c",
+      };
+    } else {
+      wantedDataContainer = {
+        ...toWatchDataContainer,
+        color: hoveredWantButton ? "#52c41a" : "#a9a9a9",
+      };
+    }
+    return (
+      <>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            gap: inline ? "10px" : "18px",
+            marginTop: inline ? "0" : "0px",
+            width: inline ? "auto" : "100%",
+          }}
+        >
+          <div
+            onClick={() => {
+              if (!isWatched) {
+                let newUserData = {
+                  ...userData,
+                  moviesSeen: [...userData.moviesSeen, id],
+                };
+                setUserData(newUserData);
+              } else {
+                let newUserData = {
+                  ...userData,
+                  moviesSeen: userData.moviesSeen.filter((x) => x !== id),
+                };
+                setUserData(newUserData);
+              }
+
+              MovieAPI.setWatchedState(userData.username, id, !isWatched)
+                .then((response) => response.json())
+                .then((response) => {
+                  if (!response.success) {
+                    alert(response.message);
+                  }
+                });
+            }}
+            onMouseEnter={() => setHoveredSeenButton(true)}
+            onMouseLeave={() => setHoveredSeenButton(false)}
+            className="zoom-on-hover"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: inline ? "100px" : "160px",
+              padding: inline ? "0" : "8px 12px",
+              cursor: "pointer",
+              color: isWatched ? "#4169e3" : hoveredSeenButton ? "#52c41a" : "#a9a9a9",
+            }}
+          >
+            <span style={filmIcon} className="fas fa-film"></span>
+            <span style={{ ...buttonLabelStyle, fontSize: inline ? "inherit" : "16px" }}>SEEN</span>
+          </div>
+          <div
+            onClick={() => {
+              if (!isWanted) {
+                let newUserData = {
+                  ...userData,
+                  moviesToWatch: [...userData.moviesToWatch, id],
+                };
+                setUserData(newUserData);
+              } else {
+                let newUserData = {
+                  ...userData,
+                  moviesToWatch: userData.moviesToWatch.filter((x) => x !== id),
+                };
+                setUserData(newUserData);
+              }
+              MovieAPI.setWantToWatchState(userData.username, id, !isWanted)
+                .then((response) => response.json())
+                .then((response) => {
+                  if (!response.success) {
+                    alert(response.message);
+                  }
+                });
+            }}
+            onMouseEnter={() => setHoveredWantButton(true)}
+            onMouseLeave={() => setHoveredWantButton(false)}
+            className="zoom-on-hover"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: inline ? "100px" : "160px",
+              padding: inline ? "0" : "8px 12px",
+              cursor: "pointer",
+              color: isWanted ? "#dc143c" : hoveredWantButton ? "#52c41a" : "#a9a9a9",
+            }}
+          >
+            <span style={heartIcon} className="fas fa-heart"></span>
+            <span style={{ ...buttonLabelStyle, fontSize: inline ? "inherit" : "16px" }}>WANT {isWanted}</span>
+          </div>
+        </div>
+      </>
+    );
+  }
+  return <></>;
+}
+
+function MovieModal({ movieId, visible, onClose, actorSearch, movieDataArray, userData, setUserData }) {
   const [movie, setMovie] = useState(null);
   const [loading, setLoading] = useState(true);
   const [totalMovieCount, setTotalMovieCount] = useState(0);
@@ -57,12 +224,14 @@ function MovieModal({ movieId, visible, onClose, actorSearch, movieDataArray }) 
         <div style={{ display: "flex", flexDirection: "column", width: "100%" }}>
           <h1 style={{ textAlign: "center", fontSize: "32px", fontWeight: "bold", margin: "0 0 20px 0" }}>{movie.title}</h1>
           <div className="movie-page-wrapper" style={{ width: "100%", maxWidth: "none", margin: "0" }}>
-            <img
-              className="movie-page-poster"
-              alt={movie.title + " poster"}
-              src={MovieAPI.getMoviePoster(movie.id)}
-              style={{ width: "200px", height: "auto", marginRight: "20px", marginTop: "0" }}
-            />
+            <div style={{ display: "flex", flexDirection: "column", alignItems: "center", marginRight: "20px", width: "200px" }}>
+              <img
+                className="movie-page-poster"
+                alt={movie.title + " poster"}
+                src={MovieAPI.getMoviePoster(movie.id)}
+                style={{ width: "200px", height: "auto", marginTop: "0" }}
+              />
+            </div>
             <div className="movie-detail-container">
               <div className="movie-detail">
                 <u>Release Date:</u> {new Date(movie.releaseDate).getFullYear()}
@@ -116,10 +285,18 @@ function MovieModal({ movieId, visible, onClose, actorSearch, movieDataArray }) 
               </div>
               <div
                 className="movie-detail2"
-                style={{ marginTop: "10px", textAlign: "left", fontSize: "13px", backgroundColor: "white", color: "gray" }}
+                style={{
+                  marginTop: "4px",
+                  fontSize: "13px",
+                  backgroundColor: "white",
+                  color: "gray",
+                  marginBottom: "2px",
+                  textAlign: "right",
+                }}
               >
-                id #{movie.id}
+                <span>id #{movie.id}</span>
               </div>
+              <UserMovieOptions userData={userData} id={movie.id} setUserData={setUserData} />
             </div>
           </div>
         </div>

--- a/src/ui/src/Pages/Browse/MovieModal.js
+++ b/src/ui/src/Pages/Browse/MovieModal.js
@@ -3,9 +3,11 @@ import { useState, useEffect } from "react";
 import { Modal, Spin } from "antd";
 import { Link } from "react-router-dom";
 
-function MovieModal({ movieId, visible, onClose, actorSearch }) {
+function MovieModal({ movieId, visible, onClose, actorSearch, movieDataArray }) {
   const [movie, setMovie] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [totalMovieCount, setTotalMovieCount] = useState(0);
+  const [movieIndex, setMovieIndex] = useState(0);
 
   useEffect(() => {
     if (visible && movieId) {
@@ -22,6 +24,30 @@ function MovieModal({ movieId, visible, onClose, actorSearch }) {
         });
     }
   }, [movieId, visible]);
+
+  useEffect(() => {
+    if (visible) {
+      MovieAPI.getTotalMovieCount()
+        .then((response) => {
+          console.log("Response status:", response.status);
+          console.log("Response ok:", response.ok);
+          return response.json();
+        })
+        .then((data) => {
+          console.log("Total movie count response:", data);
+          if (data.success !== false) {
+            setTotalMovieCount(data.totalCount || 0);
+          } else {
+            console.error("Backend error:", data.error);
+            setTotalMovieCount(0);
+          }
+        })
+        .catch((error) => {
+          console.error("Error fetching total movie count:", error);
+          setTotalMovieCount(0);
+        });
+    }
+  }, [visible]);
 
   return (
     <Modal visible={visible} onCancel={onClose} footer={null} width={1100} bodyStyle={{ maxHeight: "80vh", overflowY: "auto", padding: "24px" }}>
@@ -87,6 +113,12 @@ function MovieModal({ movieId, visible, onClose, actorSearch }) {
                 <a target="_blank" rel="noreferrer" href={"http://www.imdb.com/title/" + movie.imdbID}>
                   {movie.tomatoRating} / 100
                 </a>
+              </div>
+              <div
+                className="movie-detail2"
+                style={{ marginTop: "10px", textAlign: "left", fontSize: "13px", backgroundColor: "white", color: "gray" }}
+              >
+                id #{movie.id}
               </div>
             </div>
           </div>

--- a/src/ui/src/index.css
+++ b/src/ui/src/index.css
@@ -83,7 +83,7 @@ code {
 .movie-detail2 {
   padding: 2px;
   border-radius: 2px;
-  text-align: left;
+  text-align: center;
   margin: 0 auto;
 }
 

--- a/src/ui/src/index.css
+++ b/src/ui/src/index.css
@@ -80,6 +80,13 @@ code {
   margin: 0 auto;
 }
 
+.movie-detail2 {
+  padding: 2px;
+  border-radius: 2px;
+  text-align: left;
+  margin: 0 auto;
+}
+
 .movie-detail a {
   text-decoration: none;
   color: #007bff;


### PR DESCRIPTION
The movie card pop-up now displays the movie's id # from the database, for better management of the site. These id's were previously to be displayed in the url before the frontend was updated with pop-ups instead of switching pages.

I added the same Seen & Want buttons from the browse page to the movie card pop-ups. 

Also, I fixed the aligned of the Seen & Want buttons on the browse page.