### PR TITLE
Updated URLs to a safer scheme; Added page/search headers

### DIFF
--- a/src/ui/src/NavBar/Login.js
+++ b/src/ui/src/NavBar/Login.js
@@ -83,15 +83,27 @@ function Login({ userData, setUserData, onUserLoggedIn }) {
   function logoutUser() {
     setUserData();
     window.localStorage.clear();
+    history.replace({
+      pathname: "/",
+      search: "",
+      state: undefined,
+    });
   }
 
   function navigateToBrowseSearch(mode) {
-    const params = new URLSearchParams();
-    params.set("mode", mode);
+    let pathname = "/";
+
+    if (mode === "seen") {
+      pathname = "/library/watched";
+    }
+
+    if (mode === "want") {
+      pathname = "/library/watchlist";
+    }
 
     history.push({
-      pathname: "/",
-      search: `?${params.toString()}`,
+      pathname,
+      search: "",
     });
   }
 

--- a/src/ui/src/NavBar/NavBar.js
+++ b/src/ui/src/NavBar/NavBar.js
@@ -22,15 +22,89 @@ function NavBar({
   const location = useLocation();
   const hasHandledInitialLoadRef = useRef(false);
 
-  useEffect(() => {
-    const isInitialLoad = !hasHandledInitialLoadRef.current;
-    if (isInitialLoad) {
-      hasHandledInitialLoadRef.current = true;
+  function decodePathValue(pathValue) {
+    if (!pathValue) {
+      return "";
+    }
+
+    try {
+      return decodeURIComponent(pathValue);
+    } catch {
+      return "";
+    }
+  }
+
+  function getNavigationState() {
+    const pathname = location.pathname || "/";
+
+    if (pathname.startsWith("/discover/title/")) {
+      const value = decodePathValue(pathname.replace("/discover/title/", ""));
+      return { mode: "title", value };
+    }
+
+    if (pathname.startsWith("/discover/person/")) {
+      const value = decodePathValue(pathname.replace("/discover/person/", ""));
+      return { mode: "actor", value };
+    }
+
+    if (pathname.startsWith("/discover/all/person/")) {
+      const value = decodePathValue(pathname.replace("/discover/all/person/", ""));
+      return { mode: "actor", value };
+    }
+
+    if (pathname.startsWith("/discover/letter/")) {
+      const value = decodePathValue(pathname.replace("/discover/letter/", ""));
+      return { mode: "letter", value };
+    }
+
+    if (pathname === "/library/watched") {
+      return { mode: "seen", value: "" };
+    }
+
+    if (pathname === "/library/watchlist") {
+      return { mode: "want", value: "" };
+    }
+
+    if (pathname === "/") {
+      return { mode: null, value: "" };
+    }
+
+    // Backward compatibility for previous URL schemes
+    if (pathname.startsWith("/search/title/")) {
+      const value = decodePathValue(pathname.replace("/search/title/", ""));
+      return { mode: "title", value };
+    }
+
+    if (pathname.startsWith("/search/actor/")) {
+      const value = decodePathValue(pathname.replace("/search/actor/", ""));
+      return { mode: "actor", value };
+    }
+
+    if (pathname.startsWith("/browse/letter/")) {
+      const value = decodePathValue(pathname.replace("/browse/letter/", ""));
+      return { mode: "letter", value };
+    }
+
+    if (pathname === "/browse/seen") {
+      return { mode: "seen", value: "" };
+    }
+
+    if (pathname === "/browse/want") {
+      return { mode: "want", value: "" };
     }
 
     const params = new URLSearchParams(location.search);
     const mode = params.get("mode");
     const value = params.get("value") || "";
+    return { mode, value };
+  }
+
+  useEffect(() => {
+    const isInitialLoad = !hasHandledInitialLoadRef.current;
+    if (isInitialLoad) {
+      hasHandledInitialLoadRef.current = true;
+    }
+    const { mode, value } = getNavigationState();
 
     if (!mode) {
       const navigationEntry = window.performance?.getEntriesByType?.("navigation")?.[0];
@@ -50,9 +124,9 @@ function NavBar({
         return;
       }
 
-      const restoreIds = Array.isArray(location.state?.browseMovieIds) ? location.state.browseMovieIds : [];
+      const restoreIds = userData && Array.isArray(location.state?.browseMovieIds) ? location.state.browseMovieIds : [];
       const movieIds = restoreIds.map((id) => Number(id)).filter((id) => Number.isInteger(id) && id > 0);
-      if (movieIds.length > 0) {
+      if (userData && movieIds.length > 0) {
         restoreMovieIdsSearch(movieIds);
         return;
       }
@@ -107,7 +181,7 @@ function NavBar({
     }
 
     resetSearch();
-  }, [location.search, location.state, userData]);
+  }, [location.pathname, location.search, location.state, userData]);
 
   return (
     <Layout.Sider>

--- a/src/ui/src/NavBar/SearchTools.js
+++ b/src/ui/src/NavBar/SearchTools.js
@@ -1,5 +1,6 @@
 import { Input, List, Button } from "antd";
-import { useHistory } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useHistory, useLocation } from "react-router-dom";
 
 const { Search } = Input;
 
@@ -54,26 +55,83 @@ const listStyle = {};
 
 function SearchTools({ search }) {
   const history = useHistory();
+  const location = useLocation();
+  const [titleValue, setTitleValue] = useState("");
+  const [actorValue, setActorValue] = useState("");
 
-  function navigateToBrowseSearch(mode, value = "") {
-    const params = new URLSearchParams();
-
-    if (mode) {
-      params.set("mode", mode);
+  function decodePathValue(pathValue) {
+    if (!pathValue) {
+      return "";
     }
 
-    if (value && value.trim()) {
-      params.set("value", value.trim());
+    try {
+      return decodeURIComponent(pathValue);
+    } catch {
+      return "";
+    }
+  }
+
+  function navigateToBrowseSearch(mode, value = "") {
+    const trimmedValue = value && value.trim() ? value.trim() : "";
+    let pathname = "/";
+
+    if (mode === "title" && trimmedValue) {
+      pathname = `/discover/title/${encodeURIComponent(trimmedValue)}`;
+    } else if (mode === "actor" && trimmedValue) {
+      pathname = `/discover/person/${encodeURIComponent(trimmedValue)}`;
+    } else if (mode === "letter" && trimmedValue) {
+      pathname = `/discover/letter/${encodeURIComponent(trimmedValue)}`;
     }
 
     history.push({
-      pathname: "/",
-      search: params.toString() ? `?${params.toString()}` : "",
+      pathname,
+      search: "",
     });
   }
 
+  useEffect(() => {
+    const pathname = location.pathname || "/";
+    const params = new URLSearchParams(location.search || "");
+    const legacyMode = params.get("mode") || "";
+
+    if (
+      pathname === "/library/watched" ||
+      pathname === "/library/watchlist" ||
+      pathname === "/browse/seen" ||
+      pathname === "/browse/want" ||
+      legacyMode === "seen" ||
+      legacyMode === "want"
+    ) {
+      setActorValue("");
+      setTitleValue("");
+      return;
+    }
+
+    if (pathname.startsWith("/discover/title/")) {
+      const value = decodePathValue(pathname.replace("/discover/title/", ""));
+      setTitleValue(value);
+      setActorValue("");
+      return;
+    }
+
+    if (pathname.startsWith("/discover/person/")) {
+      const value = decodePathValue(pathname.replace("/discover/person/", ""));
+      setActorValue(value);
+      setTitleValue("");
+      return;
+    }
+
+    if (pathname.startsWith("/discover/all/person/")) {
+      setActorValue("");
+      setTitleValue("");
+      return;
+    }
+
+    setActorValue("");
+    setTitleValue("");
+  }, [location.pathname, location.search]);
+
   function ToggleLetterSearch(firstLetter) {
-    // Check if already viewing this letter by comparing the startsWith property
     const isAlreadySelected = search.startsWith === firstLetter;
 
     if (isAlreadySelected) {
@@ -98,8 +156,11 @@ function SearchTools({ search }) {
         <span style={searchLabelStyle}>MOVIE TITLE</span>
         <Search
           placeholder="Title"
+          value={titleValue}
+          onChange={(event) => setTitleValue(event.target.value)}
           onSearch={(value) => {
             if (value && value.trim()) {
+              setActorValue("");
               navigateToBrowseSearch("title", value);
             } else {
               navigateToBrowseSearch();
@@ -112,8 +173,11 @@ function SearchTools({ search }) {
         <span style={searchLabelStyle}>ACTOR NAME</span>
         <Search
           placeholder="Actor"
+          value={actorValue}
+          onChange={(event) => setActorValue(event.target.value)}
           onSearch={(value) => {
             if (value && value.trim()) {
+              setTitleValue("");
               navigateToBrowseSearch("actor", value);
             } else {
               navigateToBrowseSearch();

--- a/src/ui/src/Pages/Browse/Browse.js
+++ b/src/ui/src/Pages/Browse/Browse.js
@@ -13,6 +13,54 @@ function Browse({ search, userData, setUserData }) {
   const [isModalVisible, setIsModalVisible] = useState(false);
   let movieDataArray = data ? data.movies || data.randomMovies : [];
 
+  function decodePathValue(pathValue) {
+    if (!pathValue) {
+      return "";
+    }
+
+    try {
+      return decodeURIComponent(pathValue);
+    } catch {
+      return "";
+    }
+  }
+
+  function getBrowseHeaderText() {
+    const pathname = location.pathname || "/";
+
+    if (pathname.startsWith("/discover/letter/")) {
+      const value = decodePathValue(pathname.replace("/discover/letter/", ""));
+      return `Search: movies starting with '${value}'`;
+    }
+
+    if (pathname.startsWith("/discover/title/")) {
+      const value = decodePathValue(pathname.replace("/discover/title/", ""));
+      return `Search: '${value}' in movie titles`;
+    }
+
+    if (pathname.startsWith("/discover/person/")) {
+      const value = decodePathValue(pathname.replace("/discover/person/", ""));
+      return `Search: '${value}' in actor's names`;
+    }
+
+    if (pathname.startsWith("/discover/all/person/")) {
+      const value = decodePathValue(pathname.replace("/discover/all/person/", ""));
+      return `All: movies with actor '${value}'`;
+    }
+
+    if (pathname === "/library/watchlist") {
+      const wantCount = userData ? userData.moviesToWatch.length : 0;
+      return `Watchlist`;
+    }
+
+    if (pathname === "/library/watched") {
+      const seenCount = userData ? userData.moviesSeen.length : 0;
+      return `Seen movies`;
+    }
+
+    return "Browse All Movies";
+  }
+
   if (data && Array.isArray(search.restoreOrder) && search.restoreOrder.length > 0 && Array.isArray(data.movies)) {
     const movieById = new Map(data.movies.map((movie) => [movie.id, movie]));
     const orderedMovies = search.restoreOrder.map((id) => movieById.get(id)).filter(Boolean);
@@ -37,16 +85,12 @@ function Browse({ search, userData, setUserData }) {
     }
 
     const trimmedActor = actor.trim();
-    const params = new URLSearchParams();
-    params.set("mode", "actor");
-    params.set("value", trimmedActor);
-
-    const targetSearch = `?${params.toString()}`;
-    if (location.pathname === "/" && location.search === targetSearch) {
+    const targetPathname = `/discover/all/person/${encodeURIComponent(trimmedActor)}`;
+    if (location.pathname === targetPathname && !location.search) {
       return;
     }
 
-    if (!location.search && movieDataArray.length > 0) {
+    if (userData && !location.search && movieDataArray.length > 0 && location.pathname === "/") {
       const browseMovieIds = movieDataArray.map((movie) => movie.id).filter((id) => Number.isInteger(id) && id > 0);
       if (browseMovieIds.length > 0) {
         history.replace({
@@ -61,8 +105,8 @@ function Browse({ search, userData, setUserData }) {
     }
 
     history.push({
-      pathname: "/",
-      search: targetSearch,
+      pathname: targetPathname,
+      search: "",
     });
   };
 
@@ -72,8 +116,12 @@ function Browse({ search, userData, setUserData }) {
   }, [search]);
 
   if (data) {
+    const headerText = getBrowseHeaderText();
+    const isBrowseAllHeader = headerText === "Browse All Movies";
+
     return (
       <>
+        <div style={{ padding: "10px", fontWeight: "bold", fontSize: "16px", textAlign: isBrowseAllHeader ? "center" : "left" }}>{headerText}</div>
         <CardList
           movieDataArray={movieDataArray}
           userData={userData}


### PR DESCRIPTION
Each URL now better reflects each page type without exposing internal naming conventions. 

I added simple headers to each page to display the current type of page, especially for specific searches. This is helpful for when the browser's back / forward buttons are used and the search criteria has been altered.